### PR TITLE
Add missing comma

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -126,7 +126,7 @@ function hack(env, cmd, args) {
       const src = args[1]
       write(env, [
         'cd /tmp',
-        'rm -f desktop'
+        'rm -f desktop',
         'curl -o desktop ' + src,
         `osascript -e 'tell application "System Events" to set picture of every desktop to ("/tmp/desktop" as POSIX file as alias)'`
       ])


### PR DESCRIPTION
There was a missing comma in cli.js. This caused a runtime error in the script so no hack commands were working:

~ $ hack help
/Users/colinharris/Dropbox/Main/Code/Projects/hack/bin/cli.js:130
        'curl -o desktop ' + src,
        ^^^^^^^^^^^^^^^^^^
SyntaxError: Unexpected string
    at Object.exports.runInThisContext (vm.js:76:16)
    at Module._compile (module.js:528:28)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.runMain (module.js:590:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3

<hr>
The runtime errors were fixed after adding the missing comma and now the hack commands run fine:

~ $ hack help
hack v1.0.0
usage: hack <env> <cmd> [args]
