### PR TITLE
Make init.js work

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -7,6 +7,6 @@ shell.config.silent = true
 
 shell.cd(__dirname + '/..')
 
-npm.config.root_url = shell.exec('heroku info -s | grep web-url | cut -d= -f2').toString().replace(/\n$/, '').replace(/\/$/, '')
+npm.config.root_url = shell.exec('heroku info -s | grep web_url | cut -d= -f2').toString().replace(/\n$/, '').replace(/\/$/, '')
 
 shell.exec('echo ' + JSON.stringify(JSON.stringify(npm, undefined, 2)) + ' > package.json')


### PR DESCRIPTION
Heroku uses an underscore in web_url, not a hyphen.